### PR TITLE
PluginNameLike.kebabToTitleCase removed

### DIFF
--- a/src/main/java/walkingkooka/plugin/PluginNameLike.java
+++ b/src/main/java/walkingkooka/plugin/PluginNameLike.java
@@ -18,7 +18,6 @@
 package walkingkooka.plugin;
 
 import walkingkooka.naming.Name;
-import walkingkooka.text.CaseKind;
 import walkingkooka.text.CaseSensitivity;
 
 /**
@@ -34,20 +33,6 @@ public interface PluginNameLike<N extends Name & Comparable<N>> extends Name, Co
         return (0 == pos ?
                 PluginName.INITIAL :
                 PluginName.PART).test(c);
-    }
-
-    /**
-     * This helper is useful for names which should follow kebab-case naming standards and need to be formatted as a
-     * title case to display in a UI.
-     * <pre>
-     * day-of-month -> Day of Month
-     * </pre>
-     */
-    default String kebabToTitleCase() {
-        return CaseKind.KEBAB.change(
-                this.value(),
-                CaseKind.TITLE
-        );
     }
 
     // Comparable ......................................................................................................

--- a/src/test/java/walkingkooka/plugin/PluginNameLikeTest.java
+++ b/src/test/java/walkingkooka/plugin/PluginNameLikeTest.java
@@ -17,36 +17,12 @@
 
 package walkingkooka.plugin;
 
-import org.junit.jupiter.api.Test;
 import walkingkooka.plugin.PluginNameLikeTest.TestPluginNameLike;
 import walkingkooka.reflect.ClassTesting;
 import walkingkooka.reflect.JavaVisibility;
 import walkingkooka.text.CaseSensitivity;
 
 final class PluginNameLikeTest implements ClassTesting<TestPluginNameLike> {
-
-    @Override
-    public void testTestNaming() {
-        throw new UnsupportedOperationException();
-    }
-
-    @Test
-    public void testKebabToTitleCase() {
-        this.checkEquals(
-                "Title 123",
-                new TestPluginNameLike("title-123")
-                        .kebabToTitleCase()
-        );
-    }
-
-    @Test
-    public void testKebabToTitleCase2() {
-        this.checkEquals(
-                "Title Xyz 123",
-                new TestPluginNameLike("title-xyz-123")
-                        .kebabToTitleCase()
-        );
-    }
 
     // class............................................................................................................
 
@@ -101,5 +77,10 @@ final class PluginNameLikeTest implements ClassTesting<TestPluginNameLike> {
                     other.value
             );
         }
+    }
+
+    @Override
+    public void testTestNaming() {
+        throw new UnsupportedOperationException();
     }
 }


### PR DESCRIPTION
- Not useful because ExpressionFunctionName cant implement PluginNameLike.