### PR TITLE
PluginInfoSetLike.parse support extra spaces

### DIFF
--- a/src/main/java/walkingkooka/plugin/PluginInfoSetLikeParser.java
+++ b/src/main/java/walkingkooka/plugin/PluginInfoSetLikeParser.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright 2024 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package walkingkooka.plugin;
+
+import walkingkooka.InvalidCharacterException;
+import walkingkooka.naming.Name;
+import walkingkooka.predicate.character.CharPredicates;
+import walkingkooka.text.cursor.TextCursor;
+import walkingkooka.text.cursor.TextCursors;
+import walkingkooka.text.cursor.parser.Parser;
+import walkingkooka.text.cursor.parser.ParserContext;
+import walkingkooka.text.cursor.parser.ParserContexts;
+import walkingkooka.text.cursor.parser.ParserToken;
+import walkingkooka.text.cursor.parser.Parsers;
+
+import java.util.function.Function;
+
+final class PluginInfoSetLikeParser<N extends Name & Comparable<N>, I extends PluginInfoLike<I, N>> {
+
+    static <N extends Name & Comparable<N>, I extends PluginInfoLike<I, N>> PluginInfoSetLikeParser<N, I> with(final String text,
+                                                                                                               final Function<String, I> infoParser) {
+        return new PluginInfoSetLikeParser<>(
+                text,
+                infoParser
+        );
+    }
+
+    private PluginInfoSetLikeParser(final String text,
+                                    final Function<String, I> infoParser) {
+        this.text = text;
+        this.cursor = TextCursors.charSequence(text);
+        this.infoParser = infoParser;
+    }
+
+    String spaces() {
+        return SPACES.parse(
+                        this.cursor,
+                        CONTEXT
+                ).map(ParserToken::text)
+                .orElse("");
+    }
+
+    private final static Parser<ParserContext> SPACES = Parsers.stringCharPredicate(
+            CharPredicates.is(' '),
+            1,
+            Character.MAX_VALUE
+    );
+
+    I info() {
+        final String url = this.url();
+        final String spaces = this.spaces();
+        final String name = this.name();
+
+        final String token = url +
+                spaces +
+                name;
+
+        try {
+            return this.infoParser.apply(token);
+        } catch (final InvalidCharacterException cause) {
+            throw this.handleInvalidCharacterException(
+                    cause,
+                    token
+            );
+        }
+    }
+
+    private final Function<String, I> infoParser;
+
+    private String url() {
+        return URL.parse(
+                        this.cursor,
+                        CONTEXT
+                ).map(ParserToken::text)
+                .orElse("");
+    }
+
+    private final static Parser<ParserContext> URL = Parsers.stringCharPredicate(
+            CharPredicates.any(" ").negate(),
+            1,
+            Character.MAX_VALUE
+    );
+
+    private String name() {
+        return NAME.parse(
+                        this.cursor,
+                        CONTEXT
+                ).map(ParserToken::text)
+                .orElse("");
+    }
+
+    private final static Parser<ParserContext> NAME = Parsers.stringCharPredicate(
+            CharPredicates.any(" " + PluginInfoSetLike.SEPARATOR.character()).negate(),
+            1,
+            Character.MAX_VALUE
+    );
+
+    String comma() {
+        return COMMA.parse(
+                        this.cursor,
+                        CONTEXT
+                ).map(ParserToken::text)
+                .orElse("");
+    }
+
+    private final static Parser<ParserContext> COMMA = Parsers.character(
+            CharPredicates.is(
+                    PluginInfoSetLike.SEPARATOR.character()
+            )
+    );
+
+    boolean isEmpty() {
+        return this.cursor.isEmpty();
+    }
+
+    private final static ParserContext CONTEXT = ParserContexts.fake();
+
+    private final String text;
+
+    private final TextCursor cursor;
+
+    private InvalidCharacterException handleInvalidCharacterException(final InvalidCharacterException cause,
+                                                                      final String token) {
+        return cause.setTextAndPosition(
+                this.text,
+                this.cursor.lineInfo()
+                        .textOffset() -
+                        token.length() +
+                        cause.position()
+        );
+    }
+
+    void invalidCharacterException() {
+        throw new InvalidCharacterException(
+            this.text,
+                this.cursor.lineInfo()
+                        .textOffset()
+        );
+    }
+}

--- a/src/test/java/walkingkooka/plugin/PluginInfoSetLikeParserTest.java
+++ b/src/test/java/walkingkooka/plugin/PluginInfoSetLikeParserTest.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2024 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package walkingkooka.plugin;
+
+import walkingkooka.Cast;
+import walkingkooka.reflect.ClassTesting;
+import walkingkooka.reflect.JavaVisibility;
+
+public final class PluginInfoSetLikeParserTest implements ClassTesting<PluginInfoSetLikeParser<?, ?>> {
+
+    @Override
+    public Class<PluginInfoSetLikeParser<?, ?>> type() {
+        return Cast.to(PluginInfoSetLikeParser.class);
+    }
+
+    @Override
+    public JavaVisibility typeVisibility() {
+        return JavaVisibility.PACKAGE_PRIVATE;
+    }
+}

--- a/src/test/java/walkingkooka/plugin/PluginInfoSetLikeTest.java
+++ b/src/test/java/walkingkooka/plugin/PluginInfoSetLikeTest.java
@@ -471,15 +471,136 @@ public final class PluginInfoSetLikeTest implements PluginInfoSetLikeTesting<Tes
         return TestPluginInfoSet.class;
     }
 
+    // parse............................................................................................................
     @Override
     public void testParseStringEmptyFails() {
         throw new UnsupportedOperationException();
+    }
+
+    @Test
+    public void testParseEmpty() {
+        this.parseStringAndCheck(
+                "",
+                new TestPluginInfoSet(
+                        Sets.empty()
+                )
+        );
+    }
+
+    @Test
+    public void testParseUrlStringName() {
+        final String text = "https://example.com/1 test-1";
+
+        this.parseStringAndCheck(
+                text,
+                new TestPluginInfoSet(
+                    Sets.of(
+                            TestPluginInfo.parse(text)
+                    )
+                )
+        );
+    }
+
+    @Test
+    public void testParseStringUrlStringNameString() {
+        final String text = " https://example.com/1 test-1 ";
+
+        this.parseStringAndCheck(
+                text,
+                new TestPluginInfoSet(
+                        Sets.of(
+                                TestPluginInfo.parse(text)
+                        )
+                )
+        );
+    }
+
+    @Test
+    public void testParseUrlStringNameCommaFails() {
+        this.parseStringFails(
+                "https://example.com/1 test-1,",
+                new IllegalArgumentException("Missing url")
+        );
+    }
+
+    @Test
+    public void testParseUrlStringNameCommaSpaceFails() {
+        this.parseStringFails(
+                "https://example.com/1 test-1,   ",
+                new IllegalArgumentException("Missing url")
+        );
+    }
+
+    @Test
+    public void testParseUrlStringNameCommaUrlFails() {
+        this.parseStringFails(
+                "https://example.com/1 test-1,https://example.com/2",
+                new IllegalArgumentException("Missing name")
+        );
+    }
+
+    @Test
+    public void testParseUrlStringNameCommaUrlStringFails() {
+        this.parseStringFails(
+                "https://example.com/1 test-1,https://example.com/2 ",
+                new IllegalArgumentException("Missing name")
+        );
+    }
+
+    @Test
+    public void testParseStringUrlStringNameStringCommaUrlStringName() {
+        final String text1 = " https://example.com/1 test-1 ";
+        final String text2 = "https://example.com/2 test-2";
+
+        this.parseStringAndCheck(
+                text1 + "," + text2,
+                new TestPluginInfoSet(
+                        Sets.of(
+                                TestPluginInfo.parse(text1),
+                                TestPluginInfo.parse(text2)
+                        )
+                )
+        );
+    }
+
+    @Test
+    public void testParseStringUrlStringNameStringCommaSpaceUrlStringNameSpace() {
+        final String text1 = " https://example.com/1 test-1 ";
+        final String text2 = " https://example.com/2 test-2 ";
+
+        this.parseStringAndCheck(
+                text1 + "," + text2,
+                new TestPluginInfoSet(
+                        Sets.of(
+                                TestPluginInfo.parse(text1),
+                                TestPluginInfo.parse(text2)
+                        )
+                )
+        );
+    }
+
+    @Test
+    public void testParseStringSpaceUrlStringSpaceNameSpaceStringCommaSpaceSpaceUrlSpaceStringNameSpaceSpace() {
+        final String text1 = "  https://example.com/1  test-1  ";
+        final String text2 = "  https://example.com/2  test-2  ";
+
+        this.parseStringAndCheck(
+                text1 + "," + text2,
+                new TestPluginInfoSet(
+                        Sets.of(
+                                TestPluginInfo.parse(text1),
+                                TestPluginInfo.parse(text2)
+                        )
+                )
+        );
     }
 
     @Override
     public TestPluginInfoSet parseString(final String text) {
         return TestPluginInfoSet.parse(text);
     }
+
+    // json.............................................................................................................
 
     @Override
     public TestPluginInfoSet unmarshall(final JsonNode json,
@@ -555,8 +676,6 @@ public final class PluginInfoSetLikeTest implements PluginInfoSetLikeTesting<Tes
             final TestPluginInfoSet copy = new TestPluginInfoSet(elements);
             return this.equals(copy) ? this : copy;
         }
-
-
 
         @Override
         public Set<TestPluginInfo> toSet() {

--- a/src/test/java/walkingkooka/plugin/PluginInfoSetLikeTestingTest.java
+++ b/src/test/java/walkingkooka/plugin/PluginInfoSetLikeTestingTest.java
@@ -80,7 +80,7 @@ public final class PluginInfoSetLikeTestingTest implements PluginInfoSetLikeTest
     }
 
     @Test
-    public void testParseInfoFails() {
+    public void testParseUrlSpaceNameFails() {
         final String text = "https://example.com/test-123 test/123";
         this.parseStringInvalidCharacterFails(
                 text,
@@ -89,7 +89,7 @@ public final class PluginInfoSetLikeTestingTest implements PluginInfoSetLikeTest
     }
 
     @Test
-    public void testParseInfoMissingNameFails() {
+    public void testParseInfoCommaUrlSpaceMissingNameFails() {
         final String text = "https://example.com/test-111 test-111,https://example.com/test-222";
         this.parseStringFails(
                 text,
@@ -98,9 +98,54 @@ public final class PluginInfoSetLikeTestingTest implements PluginInfoSetLikeTest
     }
 
     @Test
-    public void testParseOne() {
+    public void testParseUrlSpaceName() {
         this.parseStringAndCheck(
                 "https://example.com/test-123 test-123",
+                new TestPluginInfoSet(
+                        Sets.of(
+                                new TestPluginInfo(
+                                        "https://example.com/test-123",
+                                        "test-123"
+                                )
+                        )
+                )
+        );
+    }
+
+    @Test
+    public void testParseSpaceUrlSpaceName() {
+        this.parseStringAndCheck(
+                " https://example.com/test-123 test-123",
+                new TestPluginInfoSet(
+                        Sets.of(
+                                new TestPluginInfo(
+                                        "https://example.com/test-123",
+                                        "test-123"
+                                )
+                        )
+                )
+        );
+    }
+
+    @Test
+    public void testParseSpaceSpaceUrlSpaceName() {
+        this.parseStringAndCheck(
+                "  https://example.com/test-123 test-123",
+                new TestPluginInfoSet(
+                        Sets.of(
+                                new TestPluginInfo(
+                                        "https://example.com/test-123",
+                                        "test-123"
+                                )
+                        )
+                )
+        );
+    }
+
+    @Test
+    public void testParseUrlSpaceSpaceName() {
+        this.parseStringAndCheck(
+                "https://example.com/test-123  test-123",
                 new TestPluginInfoSet(
                         Sets.of(
                                 new TestPluginInfo(


### PR DESCRIPTION
- Closes https://github.com/mP1/walkingkooka-plugin/issues/184
- PluginInfoSetLike.parse should support ignored whitespace around tokens.