### PR TITLE
PluginInfoLike marshall to JsonString

### DIFF
--- a/src/main/java/walkingkooka/plugin/PluginInfo.java
+++ b/src/main/java/walkingkooka/plugin/PluginInfo.java
@@ -102,7 +102,7 @@ public final class PluginInfo implements PluginInfoLike<PluginInfo, PluginName> 
         return PluginInfoLike.unmarshall(
                 node,
                 context,
-                PluginName.class,
+                PluginName::with,
                 PluginInfo::with
         );
     }

--- a/src/main/java/walkingkooka/plugin/PluginInfoLike.java
+++ b/src/main/java/walkingkooka/plugin/PluginInfoLike.java
@@ -24,7 +24,6 @@ import walkingkooka.net.AbsoluteUrl;
 import walkingkooka.net.HasAbsoluteUrl;
 import walkingkooka.net.http.server.hateos.HateosResource;
 import walkingkooka.tree.json.JsonNode;
-import walkingkooka.tree.json.JsonPropertyName;
 import walkingkooka.tree.json.marshall.JsonNodeMarshallContext;
 import walkingkooka.tree.json.marshall.JsonNodeUnmarshallContext;
 
@@ -137,56 +136,24 @@ public interface PluginInfoLike<I extends PluginInfoLike<I, N>, N extends Name &
     default JsonNode marshall(final JsonNodeMarshallContext context) {
         Objects.requireNonNull(context, "context");
 
-        return JsonNode.object()
-                .set(
-                        PluginInfoLikeJsonConstants.URL_PROPERTY,
-                        context.marshall(this.url())
-                ).set(
-                        PluginInfoLikeJsonConstants.NAME_PROPERTY,
-                        context.marshall(this.name())
-                );
+        return JsonNode.string(
+                this.toString()
+        );
     }
 
     static <I extends PluginInfoLike<I, N>, N extends Name & Comparable<N>> I unmarshall(final JsonNode node,
                                                                                          final JsonNodeUnmarshallContext context,
-                                                                                         final Class<N> nameType,
+                                                                                         final Function<String, N> nameFactory,
                                                                                          final BiFunction<AbsoluteUrl, N, I> factory) {
         Objects.requireNonNull(node, "node");
         Objects.requireNonNull(context, "context");
-        Objects.requireNonNull(nameType, "nameType");
+        Objects.requireNonNull(nameFactory, "nameFactory");
         Objects.requireNonNull(factory, "factory");
 
-        AbsoluteUrl url = null;
-        N name = null;
-
-        for (final JsonNode child : node.objectOrFail().children()) {
-            final JsonPropertyName jsonPropertyName = child.name();
-
-            switch (jsonPropertyName.value()) {
-                case PluginInfoLikeJsonConstants.URL_PROPERTY_STRING:
-                    url = context.unmarshall(
-                            child,
-                            AbsoluteUrl.class
-                    );
-                    break;
-                case PluginInfoLikeJsonConstants.NAME_PROPERTY_STRING:
-                    name = context.unmarshall(
-                            child,
-                            nameType
-                    );
-                    break;
-                default:
-                    JsonNodeUnmarshallContext.unknownPropertyPresent(
-                            jsonPropertyName,
-                            node
-                    );
-                    break;
-            }
-        }
-
-        return factory.apply(
-                url,
-                name
+        return parse(
+                node.stringOrFail(),
+                nameFactory,
+                factory
         );
     }
 }

--- a/src/test/java/walkingkooka/plugin/PlugInfoLikeTestingTest.java
+++ b/src/test/java/walkingkooka/plugin/PlugInfoLikeTestingTest.java
@@ -156,7 +156,7 @@ public final class PlugInfoLikeTestingTest implements PluginInfoLikeTesting<Test
         return PluginInfoLike.unmarshall(
                 node,
                 context,
-                StringName.class,
+                Names::string,
                 TestPluginInfoLike::new
         );
     }

--- a/src/test/java/walkingkooka/plugin/PluginInfoLikeTest.java
+++ b/src/test/java/walkingkooka/plugin/PluginInfoLikeTest.java
@@ -295,7 +295,7 @@ public final class PluginInfoLikeTest implements PluginInfoLikeTesting<TestPlugi
             return PluginInfoLike.unmarshall(
                     node,
                     context,
-                    StringName.class,
+                    Names::string,
                     TestPluginInfo::new
             );
         }

--- a/src/test/java/walkingkooka/plugin/PluginInfoSetLikeTest.java
+++ b/src/test/java/walkingkooka/plugin/PluginInfoSetLikeTest.java
@@ -754,7 +754,7 @@ public final class PluginInfoSetLikeTest implements PluginInfoSetLikeTesting<Tes
             return PluginInfoLike.unmarshall(
                     node,
                     context,
-                    StringName.class,
+                    Names::string,
                     TestPluginInfo::new
             );
         }

--- a/src/test/java/walkingkooka/plugin/PluginInfoSetLikeTestingTest.java
+++ b/src/test/java/walkingkooka/plugin/PluginInfoSetLikeTestingTest.java
@@ -386,7 +386,7 @@ public final class PluginInfoSetLikeTestingTest implements PluginInfoSetLikeTest
             return PluginInfoLike.unmarshall(
                     node,
                     context,
-                    StringName.class,
+                    Names::string,
                     TestPluginInfo::new
             );
         }


### PR DESCRIPTION
- Closes https://github.com/mP1/walkingkooka-plugin/issues/91
- PluginInfoLike marshall should be a String that is parsed by PluginInfoLike.parse and not an Object with url and name