### PR TITLE
PluginAliasSet.merge replace/concat FIX

### DIFF
--- a/src/main/java/walkingkooka/plugin/PluginAliasSet.java
+++ b/src/main/java/walkingkooka/plugin/PluginAliasSet.java
@@ -459,10 +459,18 @@ public final class PluginAliasSet<N extends Name & Comparable<N>,
                                     .name()
                     );
                     if (null != providerInfo) {
-                        newInfos = newInfos.replace(
-                                providerInfo,
-                                providerInfo.setName(aliasName)
-                        );
+
+                        if (newInfos.contains(providerInfo)) {
+                            newInfos = newInfos.replace(
+                                    providerInfo,
+                                    providerInfo.setName(aliasName)
+                            );
+
+                        } else {
+                            newInfos = newInfos.concat(
+                                    providerInfo.setName(aliasName)
+                            );
+                        }
                     }
                 }
             }


### PR DESCRIPTION
- This FIX is necessary because previously ImmutableSet.replace always concat even if old didnt exist