### PR TITLE
PluginAlias.compareTo both missing selectors FIX

### DIFF
--- a/src/main/java/walkingkooka/plugin/PluginAlias.java
+++ b/src/main/java/walkingkooka/plugin/PluginAlias.java
@@ -111,7 +111,9 @@ public final class PluginAlias<N extends Name & Comparable<N>, S extends PluginS
                 }
             } else {
                 result = null == selector ?
-                        Comparators.LESS :
+                        null == otherSelector ?
+                                Comparators.EQUAL :
+                                Comparators.LESS :
                         Comparators.MORE;
             }
         }

--- a/src/test/java/walkingkooka/plugin/PluginAliasTest.java
+++ b/src/test/java/walkingkooka/plugin/PluginAliasTest.java
@@ -19,6 +19,7 @@ package walkingkooka.plugin;
 
 import org.junit.jupiter.api.Test;
 import walkingkooka.Cast;
+import walkingkooka.compare.ComparableTesting2;
 import walkingkooka.naming.Names;
 import walkingkooka.naming.StringName;
 import walkingkooka.net.AbsoluteUrl;
@@ -29,7 +30,8 @@ import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-public final class PluginAliasTest implements PluginAliasLikeTesting<StringName, TestPluginSelector, PluginAlias<StringName, TestPluginSelector>> {
+public final class PluginAliasTest implements PluginAliasLikeTesting<StringName, TestPluginSelector, PluginAlias<StringName, TestPluginSelector>>,
+        ComparableTesting2<PluginAlias<StringName, TestPluginSelector>> {
 
     private final static StringName NAME = Names.string("Name123");
 
@@ -182,6 +184,22 @@ public final class PluginAliasTest implements PluginAliasLikeTesting<StringName,
     }
 
     @Test
+    public void testCompareToWhenNameSameMissingSelector() {
+        this.compareToAndCheckEquals(
+                PluginAlias.with(
+                        NAME,
+                        Optional.empty(),
+                        Optional.empty()
+                ),
+                PluginAlias.with(
+                        NAME,
+                        Optional.empty(),
+                        Optional.empty()
+                )
+        );
+    }
+
+    @Test
     public void testCompareToWhenNameDifferent() {
         this.compareToAndCheckLess(
                 PluginAlias.with(
@@ -236,7 +254,23 @@ public final class PluginAliasTest implements PluginAliasLikeTesting<StringName,
     }
 
     @Test
-    public void testCompareToWhenUrlDifferent() {
+    public void testCompareToWhenUrlDifferentOneMissing() {
+        this.compareToAndCheckLess(
+                PluginAlias.with(
+                        NAME,
+                        SELECTOR,
+                        Optional.empty()
+                ),
+                PluginAlias.with(
+                        NAME,
+                        SELECTOR,
+                        URL
+                )
+        );
+    }
+
+    @Test
+    public void testCompareToWhenUrlDifferent2() {
         this.compareToAndCheckLess(
                 PluginAlias.with(
                         NAME,
@@ -256,7 +290,7 @@ public final class PluginAliasTest implements PluginAliasLikeTesting<StringName,
     }
 
     @Test
-    public void testCompareToWhenUrlDifferent2() {
+    public void testCompareToWhenUrlDifferent3() {
         this.compareToAndCheckLess(
                 PluginAlias.with(
                         NAME,


### PR DESCRIPTION
- Previously would return -1 when both left & right were missing selectors (were null).