### PR TITLE
PluginAlias.compareTo both missing urls FIX

### DIFF
--- a/src/main/java/walkingkooka/plugin/PluginAlias.java
+++ b/src/main/java/walkingkooka/plugin/PluginAlias.java
@@ -103,10 +103,11 @@ public final class PluginAlias<N extends Name & Comparable<N>, S extends PluginS
                             result = url.compareTo(otherUrl);
                         } else {
                             result = null == url ?
-                                    Comparators.LESS :
+                                    null == otherUrl ?
+                                            Comparators.EQUAL :
+                                            Comparators.LESS :
                                     Comparators.MORE;
                         }
-
                     }
                 }
             } else {

--- a/src/test/java/walkingkooka/plugin/PluginAliasTest.java
+++ b/src/test/java/walkingkooka/plugin/PluginAliasTest.java
@@ -254,6 +254,22 @@ public final class PluginAliasTest implements PluginAliasLikeTesting<StringName,
     }
 
     @Test
+    public void testCompareToWhenUrlMissing() {
+        this.compareToAndCheckEquals(
+                PluginAlias.with(
+                        NAME,
+                        SELECTOR,
+                        Optional.empty()
+                ),
+                PluginAlias.with(
+                        NAME,
+                        SELECTOR,
+                        Optional.empty()
+                )
+        );
+    }
+
+    @Test
     public void testCompareToWhenUrlDifferentOneMissing() {
         this.compareToAndCheckLess(
                 PluginAlias.with(


### PR DESCRIPTION
- Previously when name & selectors both were equal and both urls were missing -1 was returned.