### PR TITLE
PluginInfoSetLike type-parameters: N, I, IS was S, I, N

### DIFF
--- a/src/main/java/walkingkooka/plugin/FilteredProviderGuard.java
+++ b/src/main/java/walkingkooka/plugin/FilteredProviderGuard.java
@@ -30,7 +30,7 @@ public final class FilteredProviderGuard<N extends Name & Comparable<N>, S exten
 
     public static <N extends Name & Comparable<N>,
             I extends PluginInfoLike<I, N>,
-            IS extends PluginInfoSetLike<IS, I, N>,
+            IS extends PluginInfoSetLike<N, I, IS>,
             S extends PluginSelectorLike<N>,
             A extends PluginAliasLike<N, S, A>>
     FilteredProviderGuard<N, S> with(final Set<N> names,

--- a/src/main/java/walkingkooka/plugin/FilteredProviderMapper.java
+++ b/src/main/java/walkingkooka/plugin/FilteredProviderMapper.java
@@ -36,13 +36,13 @@ import java.util.function.Function;
  */
 public final class FilteredProviderMapper<N extends Name & Comparable<N>,
         I extends PluginInfoLike<I, N>,
-        IS extends PluginInfoSetLike<IS, I, N>,
+        IS extends PluginInfoSetLike<N, I, IS>,
         S extends PluginSelectorLike<N>,
         A extends PluginAliasLike<N, S, A>> {
 
     public static <N extends Name & Comparable<N>,
             I extends PluginInfoLike<I, N>,
-            IS extends PluginInfoSetLike<IS, I, N>,
+            IS extends PluginInfoSetLike<N, I, IS>,
             S extends PluginSelectorLike<N>,
             A extends PluginAliasLike<N, S, A>>
     FilteredProviderMapper<N, I, IS, S, A> with(final IS mappingInfos,

--- a/src/main/java/walkingkooka/plugin/MergedProviderMapper.java
+++ b/src/main/java/walkingkooka/plugin/MergedProviderMapper.java
@@ -34,13 +34,13 @@ import java.util.function.Function;
  */
 public final class MergedProviderMapper<N extends Name & Comparable<N>,
         I extends PluginInfoLike<I, N>,
-        IS extends PluginInfoSetLike<IS, I, N>,
+        IS extends PluginInfoSetLike<N, I, IS>,
         S extends PluginSelectorLike<N>,
         A extends PluginAliasLike<N, S, A>> {
 
     public static <N extends Name & Comparable<N>,
             I extends PluginInfoLike<I, N>,
-            IS extends PluginInfoSetLike<IS, I, N>,
+            IS extends PluginInfoSetLike<N, I, IS>,
             S extends PluginSelectorLike<N>,
             A extends PluginAliasLike<N, S, A>>
     MergedProviderMapper<N, I, IS, S, A> with(final IS renamingInfos,

--- a/src/main/java/walkingkooka/plugin/PluginAliasSet.java
+++ b/src/main/java/walkingkooka/plugin/PluginAliasSet.java
@@ -45,7 +45,7 @@ import java.util.stream.Collectors;
  */
 public final class PluginAliasSet<N extends Name & Comparable<N>,
         I extends PluginInfoLike<I, N>,
-        IS extends PluginInfoSetLike<IS, I, N>,
+        IS extends PluginInfoSetLike<N, I, IS>,
         S extends PluginSelectorLike<N>,
         A extends PluginAliasLike<N, S, A>>
         extends AbstractSet<A>
@@ -60,7 +60,7 @@ public final class PluginAliasSet<N extends Name & Comparable<N>,
 
     public static <N extends Name & Comparable<N>,
             I extends PluginInfoLike<I, N>,
-            IS extends PluginInfoSetLike<IS, I, N>,
+            IS extends PluginInfoSetLike<N, I, IS>,
             S extends PluginSelectorLike<N>,
             A extends PluginAliasLike<N, S, A>>
         PluginAliasSet<N, I, IS, S, A> parse(final String text,
@@ -81,7 +81,7 @@ public final class PluginAliasSet<N extends Name & Comparable<N>,
 
     private static <N extends Name & Comparable<N>,
             I extends PluginInfoLike<I, N>,
-            IS extends PluginInfoSetLike<IS, I, N>,
+            IS extends PluginInfoSetLike<N, I, IS>,
             S extends PluginSelectorLike<N>,
             A extends PluginAliasLike<N, S, A>>
     PluginAliasSet<N, I, IS, S, A> parse0(final PluginExpressionParser<N> parser,
@@ -157,7 +157,7 @@ public final class PluginAliasSet<N extends Name & Comparable<N>,
      */
     private static <N extends Name & Comparable<N>,
             I extends PluginInfoLike<I, N>,
-            IS extends PluginInfoSetLike<IS, I, N>,
+            IS extends PluginInfoSetLike<N, I, IS>,
             S extends PluginSelectorLike<N>,
             A extends PluginAliasLike<N, S, A>>
         Optional<S> tryParseSelector(final PluginExpressionParser<N> parser,
@@ -221,7 +221,7 @@ public final class PluginAliasSet<N extends Name & Comparable<N>,
 
     public static <N extends Name & Comparable<N>,
             I extends PluginInfoLike<I, N>,
-            IS extends PluginInfoSetLike<IS, I, N>,
+            IS extends PluginInfoSetLike<N, I, IS>,
             S extends PluginSelectorLike<N>,
             A extends PluginAliasLike<N, S, A>>
         PluginAliasSet<N, I, IS, S, A> with(final SortedSet<A> aliases,
@@ -239,7 +239,7 @@ public final class PluginAliasSet<N extends Name & Comparable<N>,
 
     private static <N extends Name & Comparable<N>,
             I extends PluginInfoLike<I, N>,
-            IS extends PluginInfoSetLike<IS, I, N>,
+            IS extends PluginInfoSetLike<N, I, IS>,
             S extends PluginSelectorLike<N>,
             A extends PluginAliasLike<N, S, A>>
         PluginAliasSet<N, I, IS, S, A> withoutCopying(final SortedSet<A> aliases,

--- a/src/main/java/walkingkooka/plugin/PluginAliasSetLike.java
+++ b/src/main/java/walkingkooka/plugin/PluginAliasSetLike.java
@@ -34,7 +34,7 @@ import java.util.SortedSet;
  */
 public interface PluginAliasSetLike<N extends Name & Comparable<N>,
         I extends PluginInfoLike<I, N>,
-        IS extends PluginInfoSetLike<IS, I, N>,
+        IS extends PluginInfoSetLike<N, I, IS>,
         S extends PluginSelectorLike<N>,
         A extends PluginAliasLike<N, S, A>,
         AS extends PluginAliasSetLike<N, I, IS, S, A, AS>>

--- a/src/main/java/walkingkooka/plugin/PluginAliasSetLikeTesting.java
+++ b/src/main/java/walkingkooka/plugin/PluginAliasSetLikeTesting.java
@@ -34,7 +34,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public interface PluginAliasSetLikeTesting<N extends Name & Comparable<N>,
         I extends PluginInfoLike<I, N>,
-        IS extends PluginInfoSetLike<IS, I, N>,
+        IS extends PluginInfoSetLike<N, I, IS>,
         S extends PluginSelectorLike<N>,
         A extends PluginAliasLike<N, S, A>,
         AS extends PluginAliasSetLike<N, I, IS, S, A, AS>>

--- a/src/main/java/walkingkooka/plugin/PluginHelper.java
+++ b/src/main/java/walkingkooka/plugin/PluginHelper.java
@@ -32,7 +32,7 @@ import java.util.function.Function;
  */
 public interface PluginHelper<N extends Name & Comparable<N>,
         I extends PluginInfoLike<I, N>,
-        IS extends PluginInfoSetLike<IS, I, N>,
+        IS extends PluginInfoSetLike<N, I, IS>,
         S extends PluginSelectorLike<N>,
         A extends PluginAliasLike<N, S, A>> {
 

--- a/src/main/java/walkingkooka/plugin/PluginHelperTesting.java
+++ b/src/main/java/walkingkooka/plugin/PluginHelperTesting.java
@@ -33,7 +33,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 public interface PluginHelperTesting<H extends PluginHelper<N, I, IS, S, A>,
         N extends Name & Comparable<N>,
         I extends PluginInfoLike<I, N>,
-        IS extends PluginInfoSetLike<IS, I, N>,
+        IS extends PluginInfoSetLike<N, I, IS>,
         S extends PluginSelectorLike<N>,
         A extends PluginAliasLike<N, S, A>>
             extends ClassTesting<H> {

--- a/src/main/java/walkingkooka/plugin/PluginInfoSetLike.java
+++ b/src/main/java/walkingkooka/plugin/PluginInfoSetLike.java
@@ -32,7 +32,7 @@ import java.util.Set;
 /**
  * A {@link Set} that holds {@link PluginInfoLike} and a few related helpers.
  */
-public interface PluginInfoSetLike<S extends PluginInfoSetLike<S, I, N>, I extends PluginInfoLike<I, N>, N extends Name & Comparable<N>> extends ImmutableSet<I>,
+public interface PluginInfoSetLike<N extends Name & Comparable<N>, I extends PluginInfoLike<I, N>, IS extends PluginInfoSetLike<N, I, IS>> extends ImmutableSet<I>,
         HasText,
         HasUrlFragment,
         TreePrintable {
@@ -47,14 +47,14 @@ public interface PluginInfoSetLike<S extends PluginInfoSetLike<S, I, N>, I exten
     /**
      * Returns a filtered {@link PluginInfoSetLike} only keeping {@link PluginInfoLike} that exist in the provider with the same {@link AbsoluteUrl}.
      */
-    S filter(final S infos);
+    IS filter(final IS infos);
 
     // renameIfPresent..................................................................................................
 
     /**
      * Renames any infos if another {@link PluginNameLike} is present, that is another info with the same {@link AbsoluteUrl}.
      */
-    S renameIfPresent(final S renameInfos);
+    IS renameIfPresent(final IS renameInfos);
 
     /**
      * Returns all the names in this set.
@@ -68,20 +68,20 @@ public interface PluginInfoSetLike<S extends PluginInfoSetLike<S, I, N>, I exten
 
     // ImmutableSet.....................................................................................................
     @Override
-    S concat(final I info);
+    IS concat(final I info);
 
     @Override
-    S delete(final I info);
+    IS delete(final I info);
 
     @Override
-    S deleteAll(final Collection<I> infos);
+    IS deleteAll(final Collection<I> infos);
 
     @Override
-    S replace(final I newInfo,
+    IS replace(final I newInfo,
               final I oldInfo);
 
     @Override
-    S setElements(final Set<I> newElements);
+    IS setElements(final Set<I> newElements);
 
     // HasUrlFragment...................................................................................................
 

--- a/src/main/java/walkingkooka/plugin/PluginInfoSetLikeTesting.java
+++ b/src/main/java/walkingkooka/plugin/PluginInfoSetLikeTesting.java
@@ -25,9 +25,9 @@ import walkingkooka.test.ParseStringTesting;
 import walkingkooka.text.CharacterConstant;
 import walkingkooka.text.HasTextTesting;
 
-public interface PluginInfoSetLikeTesting<S extends PluginInfoSetLike<S, I, N>, I extends PluginInfoLike<I, N>, N extends Name & Comparable<N>> extends ImmutableSetTesting<S, I>,
-        HateosResourceSetTesting<S, I, N>,
-        ParseStringTesting<S>,
+public interface PluginInfoSetLikeTesting<N extends Name & Comparable<N>, I extends PluginInfoLike<I, N>, IS extends PluginInfoSetLike<N, I, IS>> extends ImmutableSetTesting<IS, I>,
+        HateosResourceSetTesting<IS, I, N>,
+        ParseStringTesting<IS>,
         HasTextTesting {
 
     // empty............................................................................................................
@@ -35,7 +35,7 @@ public interface PluginInfoSetLikeTesting<S extends PluginInfoSetLike<S, I, N>, 
     @Test
     default void testEmpty() throws Exception {
         this.textAndCheck(
-                (S) this.type()
+                (IS) this.type()
                         .getField("EMPTY")
                         .get(null),
                 ""
@@ -44,7 +44,7 @@ public interface PluginInfoSetLikeTesting<S extends PluginInfoSetLike<S, I, N>, 
 
     @Test
     default void testEmptyConcatText() throws Exception {
-        final S set = (S) this.type()
+        final IS set = (IS) this.type()
                 .getField("EMPTY")
                 .get(null);
 
@@ -75,7 +75,7 @@ public interface PluginInfoSetLikeTesting<S extends PluginInfoSetLike<S, I, N>, 
     // json.............................................................................................................
 
     @Override
-    default S createJsonNodeMarshallingValue() {
+    default IS createJsonNodeMarshallingValue() {
         return this.createSet();
     }
 
@@ -83,7 +83,7 @@ public interface PluginInfoSetLikeTesting<S extends PluginInfoSetLike<S, I, N>, 
 
     @Test
     default void testText() {
-        final S set = this.createSet();
+        final IS set = this.createSet();
 
         this.textAndCheck(
                 set,

--- a/src/test/java/walkingkooka/plugin/PluginInfoSetLikeTest.java
+++ b/src/test/java/walkingkooka/plugin/PluginInfoSetLikeTest.java
@@ -28,11 +28,11 @@ import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-public final class PluginInfoSetLikeTest implements PluginInfoSetLikeTesting<TestPluginInfoSet, TestPluginInfo, StringName> {
+public final class PluginInfoSetLikeTest implements PluginInfoSetLikeTesting<StringName, TestPluginInfo, TestPluginInfoSet> {
 
     // filter............................................................................................................
 
-    static <S extends PluginInfoSetLike<S, I, N>, I extends PluginInfoLike<I, N>, N extends Name & Comparable<N>> S delete(final S s,
+    static <N extends Name & Comparable<N>, I extends PluginInfoLike<I, N>, S extends PluginInfoSetLike<N, I, S>> S delete(final S s,
                                                                                                                            final I i) {
         return s.delete(
                 i

--- a/src/test/java/walkingkooka/plugin/PluginInfoSetLikeTestingTest.java
+++ b/src/test/java/walkingkooka/plugin/PluginInfoSetLikeTestingTest.java
@@ -23,7 +23,7 @@ import walkingkooka.naming.StringName;
 import walkingkooka.tree.json.JsonNode;
 import walkingkooka.tree.json.marshall.JsonNodeUnmarshallContext;
 
-public final class PluginInfoSetLikeTestingTest implements PluginInfoSetLikeTesting<TestPluginInfoSet, TestPluginInfo, StringName> {
+public final class PluginInfoSetLikeTestingTest implements PluginInfoSetLikeTesting<StringName, TestPluginInfo, TestPluginInfoSet> {
 
     // parse............................................................................................................
 

--- a/src/test/java/walkingkooka/plugin/TestPluginInfoSet.java
+++ b/src/test/java/walkingkooka/plugin/TestPluginInfoSet.java
@@ -32,7 +32,7 @@ import java.util.Collection;
 import java.util.Iterator;
 import java.util.Set;
 
-final class TestPluginInfoSet extends AbstractSet<TestPluginInfo> implements PluginInfoSetLike<TestPluginInfoSet, TestPluginInfo, StringName> {
+final class TestPluginInfoSet extends AbstractSet<TestPluginInfo> implements PluginInfoSetLike<StringName, TestPluginInfo, TestPluginInfoSet> {
 
     public final static TestPluginInfoSet EMPTY = new TestPluginInfoSet(Sets.empty());
 


### PR DESCRIPTION
- The new ordering matches the ordering of other PluginXXXLike which are N, I, IS, S, A, AS