### PR TITLE
PluginAliasSetLike.deleteNameOrAlias FIX

### DIFF
--- a/src/main/java/walkingkooka/plugin/PluginAliasSetLike.java
+++ b/src/main/java/walkingkooka/plugin/PluginAliasSetLike.java
@@ -85,8 +85,13 @@ public interface PluginAliasSetLike<N extends Name & Comparable<N>,
                         .stream()
                         .filter(
                                 p -> false ==
-                                        (p.name()
-                                                .equals(nameOrAlias)
+                                        (
+                                                nameOrAlias.equals(p.name()) ||
+                                                        nameOrAlias.equals(
+                                                                p.selector()
+                                                                        .map(PluginSelectorLike::name)
+                                                                        .orElse(null)
+                                                        )
                                         )
                         ).collect(Collectors.toCollection(SortedSets::tree))
         );

--- a/src/test/java/walkingkooka/plugin/PluginAliasSetTest.java
+++ b/src/test/java/walkingkooka/plugin/PluginAliasSetTest.java
@@ -1395,10 +1395,47 @@ public final class PluginAliasSetTest implements PluginAliasSetLikeTesting<Strin
     }
 
     @Test
-    public void testDeleteNameOrAliasWithRenamed() {
+    public void testDeleteNameOrAliasWithAlias() {
         this.deleteNameOrAlias(
                 TestPluginAliasSet.parse("alias1 name1"),
-                Names.string("name1")
+                Names.string("alias1"),
+                TestPluginAliasSet.parse("")
+        );
+    }
+
+    @Test
+    public void testDeleteNameOrAliasWithAlias2() {
+        this.deleteNameOrAlias(
+                TestPluginAliasSet.parse("alias1 name1, name2"),
+                Names.string("alias1"),
+                TestPluginAliasSet.parse("name2")
+        );
+    }
+
+    @Test
+    public void testDeleteNameOrAliasWithNameNotAlias() {
+        this.deleteNameOrAlias(
+                TestPluginAliasSet.parse("alias1 name1"),
+                Names.string("name1"),
+                TestPluginAliasSet.parse("")
+        );
+    }
+
+    @Test
+    public void testDeleteNameOrAliasWithNameNotAlias2() {
+        this.deleteNameOrAlias(
+                TestPluginAliasSet.parse("alias1 name1, name2"),
+                Names.string("name1"),
+                TestPluginAliasSet.parse("name2")
+        );
+    }
+
+    @Test
+    public void testDeleteNameOrAliasWithNameNotAlias3() {
+        this.deleteNameOrAlias(
+                TestPluginAliasSet.parse("alias1 name1, alias2 name2"),
+                Names.string("name1"),
+                TestPluginAliasSet.parse("alias2 name2")
         );
     }
 


### PR DESCRIPTION
- Previously delete ignored the name of the PluginSelectorLike