### PR TITLE
PluginAliasSetLikeTesting.testContainsNameOrAliasWithNullFails FIX

### DIFF
--- a/src/main/java/walkingkooka/plugin/PluginAliasSetLikeTesting.java
+++ b/src/main/java/walkingkooka/plugin/PluginAliasSetLikeTesting.java
@@ -235,7 +235,7 @@ public interface PluginAliasSetLikeTesting<N extends Name & Comparable<N>,
         assertThrows(
                 NullPointerException.class,
                 () -> this.createSet()
-                        .name(null)
+                        .containsNameOrAlias(null)
         );
     }
 


### PR DESCRIPTION
- was calling PluginAliasSetLike.name fixed to call PluginAliasSetLike.containsNameOrAlias.