### PR TITLE
PluginAliasSet.with duplicate name check

### DIFF
--- a/src/main/java/walkingkooka/plugin/PluginAliasSet.java
+++ b/src/main/java/walkingkooka/plugin/PluginAliasSet.java
@@ -104,15 +104,17 @@ public final class PluginAliasSet<N extends Name & Comparable<N>,
                 parser.spaces();
             }
 
-            aliases.add(
-                helper.alias(
-                        PluginAlias.parse0(
-                                parser,
-                                helper,
-                                PluginAliasesProviderContext.INSTANCE
-                        )
-                )
+            final A pluginAliasLike = helper.alias(
+                    PluginAlias.parse0(
+                            parser,
+                            helper,
+                            PluginAliasesProviderContext.INSTANCE
+                    )
             );
+
+            if(false == aliases.add(pluginAliasLike)) {
+                throw new IllegalArgumentException("Duplicate " + pluginAliasLike);
+            }
             requireSeparator = true;
         }
 
@@ -177,10 +179,12 @@ public final class PluginAliasSet<N extends Name & Comparable<N>,
             if (false == maybeSelector.isPresent()) {
                 final N name = nameOrAlias;
 
-                aliasOrNameToName.put(
+                if(null != aliasOrNameToName.put(
                         name,
                         name
-                );
+                )) {
+                    throw new IllegalArgumentException("Duplicate name: " + name);
+                };
 
                 namesNotAliases.add(name);
             } else {

--- a/src/test/java/walkingkooka/plugin/PluginAliasSetTest.java
+++ b/src/test/java/walkingkooka/plugin/PluginAliasSetTest.java
@@ -598,13 +598,21 @@ public final class PluginAliasSetTest implements PluginAliasSetLikeTesting<Strin
     @Test
     public void testParseWithDuplicateNameMappingFails() {
         this.parseStringFails(
+                "plugin111, plugin111",
+                new IllegalArgumentException("Duplicate plugin111")
+        );
+    }
+
+    @Test
+    public void testParseWithDuplicateNameMappingFails2() {
+        this.parseStringFails(
                 "alias111 plugin111, alias222 plugin111",
                 new IllegalArgumentException("Duplicate alias: alias111 and alias222")
         );
     }
 
     @Test
-    public void testParseWithDuplicateNameMappingFails2() {
+    public void testParseWithDuplicateNameMappingFails3() {
         this.parseStringFails(
                 "alias111 plugin111, alias222 plugin111, plugin222",
                 new IllegalArgumentException("Duplicate alias: alias111 and alias222")


### PR DESCRIPTION
- Previously parse only complained if duplicate aliases were encountered.