### PR TITLE
PluginNameSet.InvalidCharacterException offset FIX

### DIFF
--- a/src/main/java/walkingkooka/plugin/PluginNameSet.java
+++ b/src/main/java/walkingkooka/plugin/PluginNameSet.java
@@ -17,6 +17,7 @@
 
 package walkingkooka.plugin;
 
+import walkingkooka.InvalidCharacterException;
 import walkingkooka.collect.set.ImmutableSortedSetDefaults;
 import walkingkooka.collect.set.SortedSets;
 import walkingkooka.net.HasUrlFragment;
@@ -49,7 +50,6 @@ public final class PluginNameSet extends AbstractSet<PluginName>
         Objects.requireNonNull(text, "text");
 
         final SortedSet<PluginName> names = SortedSets.tree();
-
         final PluginNameSetParser parser = PluginNameSetParser.with(
                 text
         );
@@ -60,11 +60,19 @@ public final class PluginNameSet extends AbstractSet<PluginName>
             for (; ; ) {
                 parser.spaces();
 
-                names.add(
-                        PluginName.with(
-                                parser.name()
-                        )
-                );
+                final int offset = parser.cursor.lineInfo().textOffset();
+                try {
+                    names.add(
+                            PluginName.with(
+                                    parser.name()
+                            )
+                    );
+                } catch (final InvalidCharacterException invalid) {
+                    throw invalid.setTextAndPosition(
+                            text,
+                            offset + invalid.position()
+                    );
+                }
 
                 parser.spaces();
 

--- a/src/main/java/walkingkooka/plugin/PluginNameSetParser.java
+++ b/src/main/java/walkingkooka/plugin/PluginNameSetParser.java
@@ -92,7 +92,7 @@ final class PluginNameSetParser implements CanBeEmpty {
 
     private final String text;
 
-    private final TextCursor cursor;
+    final TextCursor cursor;
 
     private InvalidCharacterException handleInvalidCharacterException(final InvalidCharacterException cause,
                                                                       final String token) {

--- a/src/test/java/walkingkooka/plugin/PluginNameSetTest.java
+++ b/src/test/java/walkingkooka/plugin/PluginNameSetTest.java
@@ -76,6 +76,22 @@ public final class PluginNameSetTest implements ImmutableSortedSetTesting<Plugin
     }
 
     @Test
+    public void testParseInvalidCharacterFails() {
+        this.parseStringInvalidCharacterFails(
+                "plugin!1, plugin2",
+                '!'
+        );
+    }
+
+    @Test
+    public void testParseInvalidCharacterSecondPluginNameFails() {
+        this.parseStringInvalidCharacterFails(
+                "plugin1, plugin2!",
+                '!'
+        );
+    }
+
+    @Test
     public void testParseEmpty() {
         assertSame(
                 PluginNameSet.EMPTY,


### PR DESCRIPTION
- Previoulsy ICE messages were local for the plugin name within a large text, thus the offset was wrong. eg "Plugin1, Plugin2!" the offset for '!' would be relaated to the start of Plugin2 and not the actual start of the entire string.