### PR TITLE
ProviderContext implements CanConvert

### DIFF
--- a/src/main/java/walkingkooka/plugin/BasicProviderContext.java
+++ b/src/main/java/walkingkooka/plugin/BasicProviderContext.java
@@ -17,6 +17,8 @@
 
 package walkingkooka.plugin;
 
+import walkingkooka.convert.CanConvert;
+import walkingkooka.convert.CanConvertDelegator;
 import walkingkooka.environment.EnvironmentContext;
 import walkingkooka.environment.EnvironmentContextDelegator;
 import walkingkooka.plugin.store.PluginStore;
@@ -26,21 +28,34 @@ import java.util.Objects;
 /**
  * A {@link ProviderContext} that delegates to a {@link EnvironmentContext}.
  */
-final class BasicProviderContext implements ProviderContext, EnvironmentContextDelegator {
+final class BasicProviderContext implements ProviderContext,
+    CanConvertDelegator,
+    EnvironmentContextDelegator {
 
-    static BasicProviderContext with(final EnvironmentContext environmentContext,
+    static BasicProviderContext with(final CanConvert canConvert,
+                                     final EnvironmentContext environmentContext,
                                      final PluginStore pluginStore) {
         return new BasicProviderContext(
+            Objects.requireNonNull(canConvert, "canConvert"),
             Objects.requireNonNull(environmentContext, "environmentContext"),
             Objects.requireNonNull(pluginStore, "pluginStore")
         );
     }
 
-    private BasicProviderContext(final EnvironmentContext environmentContext,
+    private BasicProviderContext(final CanConvert canConvert,
+                                 final EnvironmentContext environmentContext,
                                  final PluginStore pluginStore) {
+        this.canConvert = canConvert;
         this.environmentContext = environmentContext;
         this.pluginStore = pluginStore;
     }
+
+    @Override
+    public CanConvert canConvert() {
+        return this.canConvert;
+    }
+
+    private final CanConvert canConvert;
 
     @Override
     public EnvironmentContext environmentContext() {

--- a/src/main/java/walkingkooka/plugin/FakeProviderContext.java
+++ b/src/main/java/walkingkooka/plugin/FakeProviderContext.java
@@ -17,12 +17,25 @@
 
 package walkingkooka.plugin;
 
+import walkingkooka.Either;
 import walkingkooka.environment.FakeEnvironmentContext;
 import walkingkooka.plugin.store.PluginStore;
 
 public class FakeProviderContext extends FakeEnvironmentContext implements ProviderContext {
     @Override
     public PluginStore pluginStore() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean canConvert(final Object value,
+                              final Class<?> type) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public <T> Either<T, String> convert(final Object value,
+                                         final Class<T> type) {
         throw new UnsupportedOperationException();
     }
 }

--- a/src/main/java/walkingkooka/plugin/PluginAliasesProviderContext.java
+++ b/src/main/java/walkingkooka/plugin/PluginAliasesProviderContext.java
@@ -18,6 +18,7 @@
 package walkingkooka.plugin;
 
 import walkingkooka.Cast;
+import walkingkooka.Either;
 import walkingkooka.environment.EnvironmentValueName;
 import walkingkooka.net.email.EmailAddress;
 import walkingkooka.plugin.store.PluginStore;
@@ -69,6 +70,18 @@ final class PluginAliasesProviderContext implements ProviderContext {
 
     @Override
     public Optional<EmailAddress> user() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean canConvert(final Object value,
+                              final Class<?> type) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public <T> Either<T, String> convert(final Object value,
+                                         final Class<T> type) {
         throw new UnsupportedOperationException();
     }
 

--- a/src/main/java/walkingkooka/plugin/ProviderContext.java
+++ b/src/main/java/walkingkooka/plugin/ProviderContext.java
@@ -17,13 +17,15 @@
 
 package walkingkooka.plugin;
 
+import walkingkooka.convert.CanConvert;
 import walkingkooka.environment.EnvironmentContext;
 import walkingkooka.plugin.store.PluginStore;
 
 /**
  * A {@link walkingkooka.Context} that should be passed to all {@link Provider} public methods.
  */
-public interface ProviderContext extends EnvironmentContext {
+public interface ProviderContext extends EnvironmentContext,
+    CanConvert {
 
     /**
      * A {@link PluginStore} holding plugins.

--- a/src/main/java/walkingkooka/plugin/ProviderContextDelegator.java
+++ b/src/main/java/walkingkooka/plugin/ProviderContextDelegator.java
@@ -17,17 +17,15 @@
 
 package walkingkooka.plugin;
 
+import walkingkooka.convert.CanConvert;
+import walkingkooka.convert.CanConvertDelegator;
 import walkingkooka.environment.EnvironmentContext;
 import walkingkooka.environment.EnvironmentContextDelegator;
 import walkingkooka.plugin.store.PluginStore;
 
 public interface ProviderContextDelegator extends ProviderContext,
-    EnvironmentContextDelegator {
-
-    @Override
-    default EnvironmentContext environmentContext() {
-        return this.providerContext();
-    }
+    EnvironmentContextDelegator,
+    CanConvertDelegator {
 
     @Override
     default PluginStore pluginStore() {
@@ -36,4 +34,18 @@ public interface ProviderContextDelegator extends ProviderContext,
     }
 
     ProviderContext providerContext();
+
+    // EnvironmentContext...............................................................................................
+
+    @Override
+    default EnvironmentContext environmentContext() {
+        return this.providerContext();
+    }
+
+    // CanConvert.......................................................................................................
+
+    @Override
+    default CanConvert canConvert() {
+        return this.providerContext();
+    }
 }

--- a/src/main/java/walkingkooka/plugin/ProviderContexts.java
+++ b/src/main/java/walkingkooka/plugin/ProviderContexts.java
@@ -17,6 +17,7 @@
 
 package walkingkooka.plugin;
 
+import walkingkooka.convert.CanConvert;
 import walkingkooka.environment.EnvironmentContext;
 import walkingkooka.plugin.store.PluginStore;
 import walkingkooka.reflect.PublicStaticHelper;
@@ -29,9 +30,11 @@ public final class ProviderContexts implements PublicStaticHelper {
     /**
      * {@see BasicProviderContext}
      */
-    public static ProviderContext basic(final EnvironmentContext environmentContext,
+    public static ProviderContext basic(final CanConvert canConvert,
+                                        final EnvironmentContext environmentContext,
                                         final PluginStore pluginStore) {
         return BasicProviderContext.with(
+            canConvert,
             environmentContext,
             pluginStore
         );

--- a/src/test/java/walkingkooka/plugin/BasicProviderContextTest.java
+++ b/src/test/java/walkingkooka/plugin/BasicProviderContextTest.java
@@ -18,20 +18,35 @@
 package walkingkooka.plugin;
 
 import org.junit.jupiter.api.Test;
+import walkingkooka.convert.CanConvert;
+import walkingkooka.convert.ConverterContexts;
+import walkingkooka.convert.Converters;
+import walkingkooka.datetime.DateTimeContexts;
 import walkingkooka.environment.EnvironmentContext;
 import walkingkooka.environment.EnvironmentValueName;
 import walkingkooka.environment.FakeEnvironmentContext;
+import walkingkooka.math.DecimalNumberContexts;
 import walkingkooka.net.email.EmailAddress;
 import walkingkooka.plugin.store.PluginStore;
 import walkingkooka.plugin.store.PluginStores;
 
 import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.Objects;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public final class BasicProviderContextTest implements ProviderContextTesting<BasicProviderContext> {
+
+    private final static CanConvert CAN_CONVERT = ConverterContexts.basic(
+        Converters.EXCEL_1900_DATE_SYSTEM_OFFSET, // dateOffset
+        Converters.stringToLocalDate(
+            (x) -> DateTimeFormatter.ofPattern("yyyy MM dd")
+        ), // converter
+        DateTimeContexts.fake(),
+        DecimalNumberContexts.fake()
+    );
 
     private final static EnvironmentValueName<String> VAR = EnvironmentValueName.with("magic");
 
@@ -63,12 +78,26 @@ public final class BasicProviderContextTest implements ProviderContextTesting<Ba
 
     private final static PluginStore PLUGIN_STORE = PluginStores.fake();
 
+    // with.............................................................................................................
+
+    @Test
+    public void testWithNullCanConvertFails() {
+        assertThrows(
+            NullPointerException.class,
+            () -> BasicProviderContext.with(
+                null,
+                ENVIRONMENT_CONTEXT,
+                PLUGIN_STORE
+            )
+        );
+    }
 
     @Test
     public void testWithNullEnvironmentContextFails() {
         assertThrows(
             NullPointerException.class,
             () -> BasicProviderContext.with(
+                CAN_CONVERT,
                 null,
                 PLUGIN_STORE
             )
@@ -80,6 +109,7 @@ public final class BasicProviderContextTest implements ProviderContextTesting<Ba
         assertThrows(
             NullPointerException.class,
             () -> BasicProviderContext.with(
+                CAN_CONVERT,
                 ENVIRONMENT_CONTEXT,
                 null
             )
@@ -119,6 +149,7 @@ public final class BasicProviderContextTest implements ProviderContextTesting<Ba
     @Override
     public BasicProviderContext createContext() {
         return BasicProviderContext.with(
+            CAN_CONVERT,
             ENVIRONMENT_CONTEXT,
             PLUGIN_STORE
         );

--- a/src/test/java/walkingkooka/plugin/ProviderContextTestingTest.java
+++ b/src/test/java/walkingkooka/plugin/ProviderContextTestingTest.java
@@ -17,6 +17,7 @@
 
 package walkingkooka.plugin;
 
+import walkingkooka.Either;
 import walkingkooka.environment.EnvironmentContext;
 import walkingkooka.environment.EnvironmentValueName;
 import walkingkooka.net.email.EmailAddress;
@@ -47,6 +48,18 @@ public final class ProviderContextTestingTest implements ProviderContextTesting<
     }
 
     final static class TestProviderContext implements ProviderContext {
+
+        @Override
+        public boolean canConvert(final Object value,
+                                  final Class<?> type) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public <T> Either<T, String> convert(final Object value,
+                                             final Class<T> type) {
+            throw new UnsupportedOperationException();
+        }
 
         @Override
         public <T> Optional<T> environmentValue(final EnvironmentValueName<T> name) {

--- a/src/test/java/walkingkooka/plugin/store/ProviderContextDelegatorTest.java
+++ b/src/test/java/walkingkooka/plugin/store/ProviderContextDelegatorTest.java
@@ -17,6 +17,7 @@
 
 package walkingkooka.plugin.store;
 
+import walkingkooka.convert.ConverterContexts;
 import walkingkooka.environment.EnvironmentContext;
 import walkingkooka.environment.EnvironmentContexts;
 import walkingkooka.plugin.ProviderContext;
@@ -48,6 +49,7 @@ public final class ProviderContextDelegatorTest implements ProviderContextTestin
         @Override
         public ProviderContext providerContext() {
             return ProviderContexts.basic(
+                ConverterContexts.fake(),
                 EnvironmentContexts.empty(
                     LocalDateTime::now,
                     EnvironmentContext.ANONYMOUS


### PR DESCRIPTION
- This is necessary to support Providers converting String to Expression.