### PR TITLE
PluginInfoSet skips whitespace was space

### DIFF
--- a/src/main/java/walkingkooka/plugin/PluginInfoSet.java
+++ b/src/main/java/walkingkooka/plugin/PluginInfoSet.java
@@ -68,15 +68,15 @@ public final class PluginInfoSet<N extends Name & Comparable<N>, I extends Plugi
             infoParser
         );
 
-        parser.spaces();
+        parser.whitespace();
 
         if (parser.isNotEmpty()) {
             for (; ; ) {
-                parser.spaces();
+                parser.whitespace();
 
                 infos.add(parser.info());
 
-                parser.spaces();
+                parser.whitespace();
 
                 if (SEPARATOR.string().equals(parser.comma())) {
                     continue;

--- a/src/main/java/walkingkooka/plugin/PluginInfoSetLikeParser.java
+++ b/src/main/java/walkingkooka/plugin/PluginInfoSetLikeParser.java
@@ -48,27 +48,27 @@ final class PluginInfoSetLikeParser<N extends Name & Comparable<N>, I extends Pl
         this.infoParser = infoParser;
     }
 
-    String spaces() {
-        return SPACES.parse(
+    String whitespace() {
+        return WHITESPACE.parse(
                 this.cursor,
                 CONTEXT
             ).map(ParserToken::text)
             .orElse("");
     }
 
-    private final static Parser<ParserContext> SPACES = Parsers.charPredicateString(
-        CharPredicates.is(' '),
+    private final static Parser<ParserContext> WHITESPACE = Parsers.charPredicateString(
+        CharPredicates.whitespace(),
         1,
         Character.MAX_VALUE
     );
 
     I info() {
         final String url = this.url();
-        final String spaces = this.spaces();
+        final String whitespace = this.whitespace();
         final String name = this.name();
 
         final String token = url +
-            spaces +
+            whitespace +
             name;
 
         try {
@@ -105,10 +105,11 @@ final class PluginInfoSetLikeParser<N extends Name & Comparable<N>, I extends Pl
             .orElse("");
     }
 
-    private final static Parser<ParserContext> NAME = Parsers.charPredicateString(
-        CharPredicates.any(" " + PluginInfoSetLike.SEPARATOR.character()).negate(),
-        1,
-        Character.MAX_VALUE
+    private final static Parser<ParserContext> NAME = Parsers.initialAndPartCharPredicateString(
+        PluginName.INITIAL,
+        PluginName.PART,
+        PluginName.MIN_LENGTH,
+        PluginName.MAX_LENGTH
     );
 
     String comma() {

--- a/src/test/java/walkingkooka/plugin/PluginInfoSetTest.java
+++ b/src/test/java/walkingkooka/plugin/PluginInfoSetTest.java
@@ -275,6 +275,16 @@ public final class PluginInfoSetTest implements ImmutableSetTesting<PluginInfoSe
     }
 
     @Test
+    public void testParseWhitespaceInfoWhitespace() {
+        this.parseStringAndCheck(
+            "\t" + INFO1 + "\t",
+            PluginInfoSet.with(
+                Sets.of(INFO1)
+            )
+        );
+    }
+
+    @Test
     public void testParseInfoCommaInfo() {
         this.parseStringAndCheck(
             "" + INFO1 + "," + INFO2,
@@ -291,6 +301,19 @@ public final class PluginInfoSetTest implements ImmutableSetTesting<PluginInfoSe
     public void testParseInfoSpaceCommaSpaceInfo() {
         this.parseStringAndCheck(
             "" + INFO1 + " , " + INFO2,
+            PluginInfoSet.with(
+                Sets.of(
+                    INFO1,
+                    INFO2
+                )
+            )
+        );
+    }
+
+    @Test
+    public void testParseInfoWhitespaceCommaWhitespaceInfo() {
+        this.parseStringAndCheck(
+            "\r" + INFO1 + "\t,\t" + INFO2,
             PluginInfoSet.with(
                 Sets.of(
                     INFO1,


### PR DESCRIPTION
- Also improved definition of PluginInfoSetLikeParser.NAME referencing PluginName.XXX

- Closes https://github.com/mP1/walkingkooka-plugin/issues/479
- PluginInfoSet currently ignores whitespace between token, update to support whitespace