### PR TITLE
PluginAliasSetLike.setElementsFailIfDifferent(Set) cast FIX

### DIFF
--- a/src/main/java/walkingkooka/plugin/PluginAliasSetLike.java
+++ b/src/main/java/walkingkooka/plugin/PluginAliasSetLike.java
@@ -166,7 +166,13 @@ public interface PluginAliasSetLike<N extends Name & Comparable<N>,
 
     @Override
     default AS setElementsFailIfDifferent(final Set<A> aliases) {
-        return this.setElementsFailIfDifferent((SortedSet<A>) aliases);
+        Objects.requireNonNull(aliases, "aliases");
+
+        return this.setElementsFailIfDifferent(
+            aliases instanceof SortedSet ?
+                (SortedSet<A>) aliases :
+                new TreeSet<>(aliases)
+        );
     }
 
     @Override

--- a/src/test/java/walkingkooka/plugin/PluginAliasSetLikeTest.java
+++ b/src/test/java/walkingkooka/plugin/PluginAliasSetLikeTest.java
@@ -79,6 +79,50 @@ public final class PluginAliasSetLikeTest implements ClassTesting<PluginAliasSet
         );
     }
 
+    @Test
+    public void testSetElementsFailIfDifferentSetWithSet() {
+        final TestPluginAlias alias = TestPluginAlias.with(
+            Names.string("Name"),
+            Optional.empty(), // selector
+            Optional.empty() // url
+        );
+
+        final TestPluginAliasSet test = TestPluginAliasSet.with(
+            SortedSets.of(alias)
+        );
+
+        this.checkEquals(
+            TestPluginAliasSet.with(
+                SortedSets.of(alias)
+            ),
+            test.setElementsFailIfDifferent(
+                Sets.of(alias)
+            )
+        );
+    }
+
+    @Test
+    public void testSetElementsFailIfDifferentSetWithSortedSet() {
+        final TestPluginAlias alias = TestPluginAlias.with(
+            Names.string("Name"),
+            Optional.empty(), // selector
+            Optional.empty() // url
+        );
+
+        final TestPluginAliasSet test = TestPluginAliasSet.with(
+            SortedSets.of(alias)
+        );
+
+        this.checkEquals(
+            TestPluginAliasSet.with(
+                SortedSets.of(alias)
+            ),
+            test.setElementsFailIfDifferent(
+                SortedSets.of(alias)
+            )
+        );
+    }
+
     // class............................................................................................................
 
     @Override


### PR DESCRIPTION
- Closes https://github.com/mP1/walkingkooka-plugin/issues/491
- PluginAliasSetLike.setElementsFailIfDifferent(Set) always casts to SortedSet causing ClassCastException