### PR TITLE
PluginName only lower-case letters

### DIFF
--- a/src/main/java/walkingkooka/plugin/PluginName.java
+++ b/src/main/java/walkingkooka/plugin/PluginName.java
@@ -29,7 +29,9 @@ import walkingkooka.tree.json.marshall.JsonNodeMarshallContext;
 import walkingkooka.tree.json.marshall.JsonNodeUnmarshallContext;
 
 /**
- * The {@link Name} of a component. Note component names are case-sensitive.
+ * The {@link Name} of a component. Note component names are case-sensitive and must be lower-cased and kebab-case,
+ * eg:
+ * magic-plugin-123
  */
 final public class PluginName implements PluginNameLike<PluginName> {
 
@@ -43,8 +45,7 @@ final public class PluginName implements PluginNameLike<PluginName> {
         return PluginNameLike.isChar(pos, c);
     }
 
-    final static CharPredicate INITIAL = CharPredicates.range('A', 'Z')
-        .or(CharPredicates.range('a', 'z'));
+    final static CharPredicate INITIAL = CharPredicates.range('a', 'z');
 
     final static CharPredicate PART = INITIAL.or(CharPredicates.range('0', '9'))
         .or(CharPredicates.is('-'));

--- a/src/main/java/walkingkooka/plugin/PluginNameTesting.java
+++ b/src/main/java/walkingkooka/plugin/PluginNameTesting.java
@@ -35,7 +35,7 @@ public interface PluginNameTesting<N extends PluginNameLike<N>> extends ClassTes
 
     @Test
     default void testSort() {
-        final N a = this.createName("STRING");
+        final N a = this.createName("aaa");
         final N b = this.createName("date-of-month");
         final N c = this.createName("text-case-insensitive");
         final N d = this.createName("month-of-year");
@@ -79,8 +79,8 @@ public interface PluginNameTesting<N extends PluginNameLike<N>> extends ClassTes
     @Override
     default String possibleValidChars(final int position) {
         return 0 == position ?
-            ASCII_LETTERS :
-            ASCII_LETTERS_DIGITS + "-";
+            ASCII_LETTERS.toLowerCase() :
+            ASCII_LETTERS_DIGITS.toLowerCase() + "-";
     }
 
     @Override

--- a/src/main/java/walkingkooka/plugin/PluginStartup.java
+++ b/src/main/java/walkingkooka/plugin/PluginStartup.java
@@ -43,7 +43,7 @@ public final class PluginStartup implements PublicStaticHelper {
         }
 
         // register json marshallers/unmarshallers.
-        final PluginName pluginName = PluginName.with("Hello");
+        final PluginName pluginName = PluginName.with("hello");
 
         PluginInfo.with(
             Url.parseAbsolute("https://example.com/Hello"),

--- a/src/test/java/walkingkooka/plugin/ClassLoaderPluginProviderTest.java
+++ b/src/test/java/walkingkooka/plugin/ClassLoaderPluginProviderTest.java
@@ -92,7 +92,7 @@ public final class ClassLoaderPluginProviderTest implements PluginProviderTestin
             //   TestPluginImpl
             final byte[] jar = JarFileTesting.jarFile(
                 "Manifest-Version: 1.0\r\n" +
-                    "plugin-name: TestPlugin123\r\n" +
+                    "plugin-name: test-plugin-123\r\n" +
                     "plugin-provider-factory-className: walkingkooka.plugin.ClassLoaderPluginProviderTest$TestPluginProviderImpl\r\n",
                 Maps.of(
                     "resource123.txt", // ignored!
@@ -229,10 +229,10 @@ public final class ClassLoaderPluginProviderTest implements PluginProviderTestin
 
     public final static AbsoluteUrl PLUGIN_PROVIDER_URL = Url.parseAbsolute("https://example.com/TestPluginProvider123");
 
-    public final static PluginName PLUGIN_NAME = PluginName.with("PluginName123");
+    public final static PluginName PLUGIN_NAME = PluginName.with("plugin-name-123");
 
     public final static PluginInfo PLUGIN_INFO = PluginInfo.with(
-        Url.parseAbsolute("https://example.com/Plugin123"),
+        Url.parseAbsolute("https://example.com/plugin-123"),
         PLUGIN_NAME
     );
 

--- a/src/test/java/walkingkooka/plugin/PluginArchiveManifestTest.java
+++ b/src/test/java/walkingkooka/plugin/PluginArchiveManifestTest.java
@@ -44,7 +44,7 @@ public final class PluginArchiveManifestTest implements HashCodeEqualsDefinedTes
     public void testFromArchive() throws IOException {
         final String manifest = (
             "Manifest-Version: 1.0\r\n" +
-                "plugin-name: TestPluginName111\r\n" +
+                "plugin-name: test-plugin-name-111\r\n" +
                 "plugin-provider-factory-className: example.TestPluginName111\r\n"
         );
 
@@ -90,7 +90,7 @@ public final class PluginArchiveManifestTest implements HashCodeEqualsDefinedTes
     public void testFromManifestManifestMissingPluginProviderFactoryClassNameFails() {
         final IllegalArgumentException thrown = assertThrows(
             IllegalArgumentException.class,
-            () -> this.createPluginArchiveManifest("plugin-name: TestPlugin123\n")
+            () -> this.createPluginArchiveManifest("plugin-name: test-plugin-123\n")
         );
 
         this.checkEquals(
@@ -125,7 +125,7 @@ public final class PluginArchiveManifestTest implements HashCodeEqualsDefinedTes
         assertThrows(
             NullPointerException.class,
             () -> PluginArchiveManifest.with(
-                PluginName.with("TestPlugin111"),
+                PluginName.with("test-plugin-111"),
                 null
             )
         );
@@ -133,7 +133,7 @@ public final class PluginArchiveManifestTest implements HashCodeEqualsDefinedTes
 
     @Test
     public void testWith() {
-        final PluginName pluginName = PluginName.with("TestPlugin123");
+        final PluginName pluginName = PluginName.with("test-plugin-123");
         final ClassName className = ClassName.with(this.getClass().getCanonicalName());
 
         final PluginArchiveManifest manifest = PluginArchiveManifest.with(
@@ -157,7 +157,7 @@ public final class PluginArchiveManifestTest implements HashCodeEqualsDefinedTes
     public void testEqualsDifferentClassName() {
         this.checkNotEquals(
             this.createPluginArchiveManifest(
-                "plugin-name: TestPlugin123\n" +
+                "plugin-name: test-plugin-123\n" +
                     "plugin-provider-factory-className: example.DifferentPluginProvider\n"
             )
         );
@@ -166,7 +166,7 @@ public final class PluginArchiveManifestTest implements HashCodeEqualsDefinedTes
     @Override
     public PluginArchiveManifest createObject() {
         return this.createPluginArchiveManifest(
-            "plugin-name: TestPlugin123\n" +
+            "plugin-name: test-plugin-123\n" +
                 "plugin-provider-factory-className: example.TestPluginProvider123\n"
         );
     }

--- a/src/test/java/walkingkooka/plugin/PluginNameSetTest.java
+++ b/src/test/java/walkingkooka/plugin/PluginNameSetTest.java
@@ -84,7 +84,7 @@ public final class PluginNameSetTest implements ImmutableSortedSetTesting<Plugin
 
     @Test
     public void testDeleteBecomesEmpty() {
-        final PluginName name = PluginName.with("Plugin111");
+        final PluginName name = PluginName.with("plugin-111");
 
         assertSame(
             PluginNameSet.EMPTY,
@@ -103,7 +103,7 @@ public final class PluginNameSetTest implements ImmutableSortedSetTesting<Plugin
             () -> this.createSet()
                 .replace(
                     null,
-                    PluginName.with("Plugin222")
+                    PluginName.with("plugin-222")
                 )
         );
     }
@@ -114,7 +114,7 @@ public final class PluginNameSetTest implements ImmutableSortedSetTesting<Plugin
             NullPointerException.class,
             () -> this.createSet()
                 .replace(
-                    PluginName.with("Plugin111"),
+                    PluginName.with("plugin-111"),
                     null
                 )
         );
@@ -137,8 +137,8 @@ public final class PluginNameSetTest implements ImmutableSortedSetTesting<Plugin
     public PluginNameSet createSet() {
         return PluginNameSet.with(
             SortedSets.of(
-                PluginName.with("Plugin111"),
-                PluginName.with("Plugin222")
+                PluginName.with("plugin-111"),
+                PluginName.with("plugin-222")
             )
         );
     }
@@ -191,7 +191,7 @@ public final class PluginNameSetTest implements ImmutableSortedSetTesting<Plugin
     @Test
     public void testParse() {
         this.parseStringAndCheck(
-            "Plugin111,Plugin222",
+            "plugin-111,plugin-222",
             this.createSet()
         );
     }
@@ -199,7 +199,7 @@ public final class PluginNameSetTest implements ImmutableSortedSetTesting<Plugin
     @Test
     public void testParseWithExtraSpaces() {
         this.parseStringAndCheck(
-            " Plugin111 , Plugin222 ",
+            " plugin-111 , plugin-222 ",
             this.createSet()
         );
     }
@@ -225,7 +225,7 @@ public final class PluginNameSetTest implements ImmutableSortedSetTesting<Plugin
     public void testText() {
         this.textAndCheck(
             this.createSet(),
-            "Plugin111,Plugin222"
+            "plugin-111,plugin-222"
         );
     }
 
@@ -235,8 +235,8 @@ public final class PluginNameSetTest implements ImmutableSortedSetTesting<Plugin
     public void testTreePrint() {
         this.treePrintAndCheck(
             this.createSet(),
-            "Plugin111\n" +
-                "Plugin222\n"
+            "plugin-111\n" +
+                "plugin-222\n"
         );
     }
 
@@ -246,7 +246,7 @@ public final class PluginNameSetTest implements ImmutableSortedSetTesting<Plugin
     public void testMarshall() {
         this.marshallAndCheck(
             this.createJsonNodeMarshallingValue(),
-            "\"Plugin111,Plugin222\""
+            "\"plugin-111,plugin-222\""
         );
     }
 
@@ -270,7 +270,7 @@ public final class PluginNameSetTest implements ImmutableSortedSetTesting<Plugin
     public void testUrlFragment() {
         this.urlFragmentAndCheck(
             this.createSet(),
-            "Plugin111,Plugin222"
+            "plugin-111,plugin-222"
         );
     }
 

--- a/src/test/java/walkingkooka/plugin/PluginNameTest.java
+++ b/src/test/java/walkingkooka/plugin/PluginNameTest.java
@@ -31,7 +31,7 @@ final public class PluginNameTest implements PluginNameTesting<PluginName> {
         assertThrows(
             InvalidCharacterException.class,
             () -> PluginName.with(
-                PluginName.SEPARATOR + "Hello"
+                PluginName.SEPARATOR + "hello"
             )
         );
     }
@@ -41,9 +41,14 @@ final public class PluginNameTest implements PluginNameTesting<PluginName> {
         assertThrows(
             InvalidCharacterException.class,
             () -> PluginName.with(
-                "Hello" + PluginName.SEPARATOR + "123"
+                "hello" + PluginName.SEPARATOR + "123"
             )
         );
+    }
+
+    @Override
+    public void testCompareDifferentCase() {
+        throw new UnsupportedOperationException();
     }
 
     // Name.............................................................................................................

--- a/src/test/java/walkingkooka/plugin/PluginProviderTestingTest.java
+++ b/src/test/java/walkingkooka/plugin/PluginProviderTestingTest.java
@@ -31,9 +31,9 @@ public final class PluginProviderTestingTest implements PluginProviderTesting<Te
 
     private final static AbsoluteUrl PLUGIN_PROVIDER_URL = Url.parseAbsolute("https://example.com/PluginProviderTestingTest");
 
-    private final static PluginName PLUGIN_NAME1 = PluginName.with("Plugin-1");
+    private final static PluginName PLUGIN_NAME1 = PluginName.with("plugin-1");
 
-    private final static PluginName PLUGIN_NAME2 = PluginName.with("Plugin-2");
+    private final static PluginName PLUGIN_NAME2 = PluginName.with("plugin-2");
 
     private final static PluginInfo<PluginName> PLUGIN_INFO1 = PluginInfo.with(
         Url.parseAbsolute("https://example.com/plugin-1"),

--- a/src/test/java/walkingkooka/plugin/store/PluginSetTest.java
+++ b/src/test/java/walkingkooka/plugin/store/PluginSetTest.java
@@ -98,7 +98,7 @@ public final class PluginSetTest implements ImmutableSortedSetTesting<PluginSet,
 
     private static Plugin plugin() {
         return Plugin.with(
-            PluginName.with("TestPlugin111"),
+            PluginName.with("test-plugin-111"),
             "test-plugin-111.jar",
             Binary.with("content".getBytes(Charset.defaultCharset())),
             EmailAddress.parse("user1@example.com"),
@@ -117,7 +117,7 @@ public final class PluginSetTest implements ImmutableSortedSetTesting<PluginSet,
     @Test
     public void testDeleteBecomesEmpty() {
         final Plugin plugin = Plugin.with(
-            PluginName.with("TestPlugin111"),
+            PluginName.with("test-plugin-111"),
             "test-plugin-111.jar",
             Binary.with("content".getBytes(Charset.defaultCharset())),
             EmailAddress.parse("user1@example.com"),
@@ -144,7 +144,7 @@ public final class PluginSetTest implements ImmutableSortedSetTesting<PluginSet,
         return PluginSet.with(
             SortedSets.of(
                 Plugin.with(
-                    PluginName.with("TestPlugin111"),
+                    PluginName.with("test-plugin-111"),
                     "test-plugin-111.jar",
                     Binary.with("content".getBytes(Charset.defaultCharset())),
                     EmailAddress.parse("user1@example.com"),
@@ -158,7 +158,7 @@ public final class PluginSetTest implements ImmutableSortedSetTesting<PluginSet,
                     )
                 ),
                 Plugin.with(
-                    PluginName.with("TestPlugin222"),
+                    PluginName.with("test-plugin-222"),
                     "test-plugin-222.jar",
                     Binary.with("content".getBytes(Charset.defaultCharset())),
                     EmailAddress.parse("user2@example.com"),
@@ -182,8 +182,8 @@ public final class PluginSetTest implements ImmutableSortedSetTesting<PluginSet,
         this.checkEquals(
             PluginNameSet.with(
                 SortedSets.of(
-                    PluginName.with("TestPlugin111"),
-                    PluginName.with("TestPlugin222")
+                    PluginName.with("test-plugin-111"),
+                    PluginName.with("test-plugin-222")
                 )
             ),
             this.createSet().names()
@@ -198,14 +198,14 @@ public final class PluginSetTest implements ImmutableSortedSetTesting<PluginSet,
             this.createJsonNodeMarshallingValue(),
             "[\n" +
                 "  {\n" +
-                "    \"name\": \"TestPlugin111\",\n" +
+                "    \"name\": \"test-plugin-111\",\n" +
                 "    \"filename\": \"test-plugin-111.jar\",\n" +
                 "    \"archive\": \"Y29udGVudA==\",\n" +
                 "    \"user\": \"user1@example.com\",\n" +
                 "    \"timestamp\": \"1999-12-31T12:58:59\"\n" +
                 "  },\n" +
                 "  {\n" +
-                "    \"name\": \"TestPlugin222\",\n" +
+                "    \"name\": \"test-plugin-222\",\n" +
                 "    \"filename\": \"test-plugin-222.jar\",\n" +
                 "    \"archive\": \"Y29udGVudA==\",\n" +
                 "    \"user\": \"user1@example.com\",\n" +
@@ -220,14 +220,14 @@ public final class PluginSetTest implements ImmutableSortedSetTesting<PluginSet,
         this.unmarshallAndCheck(
             "[\n" +
                 "  {\n" +
-                "    \"name\": \"TestPlugin111\",\n" +
+                "    \"name\": \"test-plugin-111\",\n" +
                 "    \"filename\": \"test-plugin-111.jar\",\n" +
                 "    \"archive\": \"Y29udGVudA==\",\n" +
                 "    \"user\": \"user1@example.com\",\n" +
                 "    \"timestamp\": \"1999-12-31T12:58:59\"\n" +
                 "  },\n" +
                 "  {\n" +
-                "    \"name\": \"TestPlugin222\",\n" +
+                "    \"name\": \"test-plugin-222\",\n" +
                 "    \"filename\": \"test-plugin-222.jar\",\n" +
                 "    \"archive\": \"Y29udGVudA==\",\n" +
                 "    \"user\": \"user1@example.com\",\n" +
@@ -252,7 +252,7 @@ public final class PluginSetTest implements ImmutableSortedSetTesting<PluginSet,
         return PluginSet.with(
             SortedSets.of(
                 Plugin.with(
-                    PluginName.with("TestPlugin111"),
+                    PluginName.with("test-plugin-111"),
                     "test-plugin-111.jar",
                     Binary.with("content".getBytes(Charset.defaultCharset())),
                     EmailAddress.parse("user1@example.com"),
@@ -266,7 +266,7 @@ public final class PluginSetTest implements ImmutableSortedSetTesting<PluginSet,
                     )
                 ),
                 Plugin.with(
-                    PluginName.with("TestPlugin222"),
+                    PluginName.with("test-plugin-222"),
                     "test-plugin-222.jar",
                     Binary.with("content".getBytes(Charset.defaultCharset())),
                     EmailAddress.parse("user1@example.com"),

--- a/src/test/java/walkingkooka/plugin/store/PluginTest.java
+++ b/src/test/java/walkingkooka/plugin/store/PluginTest.java
@@ -43,7 +43,7 @@ public final class PluginTest implements HashCodeEqualsDefinedTesting2<Plugin>,
     JsonNodeMarshallingTesting<Plugin>,
     HateosResourceTesting<Plugin, PluginName> {
 
-    private final static PluginName NAME = PluginName.with("TestPlugin123");
+    private final static PluginName NAME = PluginName.with("test-plugin-123");
 
     private final static String FILENAME = "file.jar";
 
@@ -180,7 +180,7 @@ public final class PluginTest implements HashCodeEqualsDefinedTesting2<Plugin>,
     @Test
     public void testCompareSort() {
         final Plugin a1 = Plugin.with(
-            PluginName.with("A1"),
+            PluginName.with("a1"),
             FILENAME,
             ARCHIVE,
             USER,
@@ -188,7 +188,7 @@ public final class PluginTest implements HashCodeEqualsDefinedTesting2<Plugin>,
         );
 
         final Plugin b2 = Plugin.with(
-            PluginName.with("B2"),
+            PluginName.with("b2"),
             FILENAME,
             ARCHIVE,
             USER,
@@ -196,7 +196,7 @@ public final class PluginTest implements HashCodeEqualsDefinedTesting2<Plugin>,
         );
 
         final Plugin c3 = Plugin.with(
-            PluginName.with("C3"),
+            PluginName.with("c3"),
             FILENAME,
             ARCHIVE,
             USER,
@@ -224,7 +224,7 @@ public final class PluginTest implements HashCodeEqualsDefinedTesting2<Plugin>,
     public void testEqualsDifferentId() {
         this.checkNotEquals(
             Plugin.with(
-                PluginName.with("Different"),
+                PluginName.with("different"),
                 FILENAME,
                 ARCHIVE,
                 USER,
@@ -310,7 +310,7 @@ public final class PluginTest implements HashCodeEqualsDefinedTesting2<Plugin>,
                 USER,
                 TIMESTAMP
             ),
-            "TestPlugin123 \"file.jar\" user@example.com 1999-12-31T12:58"
+            "test-plugin-123 \"file.jar\" user@example.com 1999-12-31T12:58"
         );
     }
 

--- a/src/test/java/walkingkooka/plugin/store/TreeMapPluginStoreTest.java
+++ b/src/test/java/walkingkooka/plugin/store/TreeMapPluginStoreTest.java
@@ -27,7 +27,7 @@ import java.time.LocalDateTime;
 
 public final class TreeMapPluginStoreTest implements PluginStoreTesting<TreeMapPluginStore> {
 
-    private final static PluginName PLUGIN_NAME = PluginName.with("TestPlugin123");
+    private final static PluginName PLUGIN_NAME = PluginName.with("test-plugin-123");
 
     @Override
     public void testAddSaveWatcherAndSaveTwiceFiresOnce() {
@@ -53,7 +53,7 @@ public final class TreeMapPluginStoreTest implements PluginStoreTesting<TreeMapP
 
     @Test
     public void testFilterWithEmptyQuery() {
-        final Plugin plugin1 = plugin("Plugin111");
+        final Plugin plugin1 = plugin("plugin-111");
 
         final TreeMapPluginStore store = TreeMapPluginStore.empty();
         store.save(plugin1);
@@ -68,8 +68,8 @@ public final class TreeMapPluginStoreTest implements PluginStoreTesting<TreeMapP
 
     @Test
     public void testFilterWithMatchesAllQuery() {
-        final Plugin plugin1 = plugin("Plugin111");
-        final Plugin plugin2 = plugin("Plugin222");
+        final Plugin plugin1 = plugin("plugin-111");
+        final Plugin plugin2 = plugin("plugin-222");
 
         final TreeMapPluginStore store = TreeMapPluginStore.empty();
         store.save(plugin1);
@@ -87,8 +87,8 @@ public final class TreeMapPluginStoreTest implements PluginStoreTesting<TreeMapP
 
     @Test
     public void testFilterWithMatchesAllOffset() {
-        final Plugin plugin1 = plugin("Plugin111");
-        final Plugin plugin2 = plugin("Plugin222");
+        final Plugin plugin1 = plugin("plugin-111");
+        final Plugin plugin2 = plugin("plugin-222");
 
         final TreeMapPluginStore store = TreeMapPluginStore.empty();
         store.save(plugin1);
@@ -105,8 +105,8 @@ public final class TreeMapPluginStoreTest implements PluginStoreTesting<TreeMapP
 
     @Test
     public void testFilterWithMatchesAllCount() {
-        final Plugin plugin1 = plugin("Plugin111");
-        final Plugin plugin2 = plugin("Plugin222");
+        final Plugin plugin1 = plugin("plugin-111");
+        final Plugin plugin2 = plugin("plugin-222");
 
         final TreeMapPluginStore store = TreeMapPluginStore.empty();
         store.save(plugin1);
@@ -123,12 +123,12 @@ public final class TreeMapPluginStoreTest implements PluginStoreTesting<TreeMapP
 
     @Test
     public void testFilterWithFilteringQueryOffsetCount() {
-        final Plugin plugin1 = plugin("Plugin111");
-        final Plugin plugin2 = plugin("Plugin222");
-        final Plugin plugin3 = plugin("Plugin333");
-        final Plugin plugin4 = plugin("Plugin444");
-        final Plugin plugin5 = plugin("Plugin555");
-        final Plugin plugin6 = plugin("Plugin666");
+        final Plugin plugin1 = plugin("plugin-111");
+        final Plugin plugin2 = plugin("plugin-222");
+        final Plugin plugin3 = plugin("plugin-333");
+        final Plugin plugin4 = plugin("plugin-444");
+        final Plugin plugin5 = plugin("plugin-555");
+        final Plugin plugin6 = plugin("plugin-666");
 
         final TreeMapPluginStore store = TreeMapPluginStore.empty();
         store.save(plugin1);


### PR DESCRIPTION
- Closes https://github.com/mP1/walkingkooka-plugin/issues/529
- PluginName: names should be kebab-case and not camel-case