### PR TITLE
POM walkingkooka-storage

### DIFF
--- a/gwt-pom.xml
+++ b/gwt-pom.xml
@@ -86,6 +86,12 @@
 
         <dependency>
             <groupId>walkingkooka</groupId>
+            <artifactId>walkingkooka-storage-gwt</artifactId>
+            <version>1.0-SNAPSHOT</version>
+        </dependency>
+
+        <dependency>
+            <groupId>walkingkooka</groupId>
             <artifactId>walkingkooka-store-gwt</artifactId>
             <version>1.0-SNAPSHOT</version>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -119,6 +119,12 @@
 
         <dependency>
             <groupId>walkingkooka</groupId>
+            <artifactId>walkingkooka-storage</artifactId>
+            <version>1.0-SNAPSHOT</version>
+        </dependency>
+
+        <dependency>
+            <groupId>walkingkooka</groupId>
             <artifactId>walkingkooka-store</artifactId>
             <version>1.0-SNAPSHOT</version>
         </dependency>


### PR DESCRIPTION
- Required to support StoragePath literals and for plugins to load from Storage