### PR TITLE
PluginInfoSet.text() separated by comma space was comma

### DIFF
--- a/src/main/java/walkingkooka/plugin/PluginInfoSet.java
+++ b/src/main/java/walkingkooka/plugin/PluginInfoSet.java
@@ -268,11 +268,19 @@ public final class PluginInfoSet<N extends Name & Comparable<N>, I extends Plugi
 
     @Override
     public String text() {
-        return SEPARATOR.toSeparatedString(
-            this,
-            Object::toString
-        );
+        if (null == this.text) {
+            this.text = this.infos.stream()
+                .map(Object::toString)
+                .collect(Collectors.joining(SEPARATOR_SPACE))
+                .trim();
+        }
+
+        return this.text;
     }
+
+    private String text;
+
+    private final static String SEPARATOR_SPACE = SEPARATOR + " ";
 
     // HasUrlFragment...................................................................................................
 

--- a/src/main/java/walkingkooka/plugin/PluginInfoSetLikeTesting.java
+++ b/src/main/java/walkingkooka/plugin/PluginInfoSetLikeTesting.java
@@ -107,7 +107,7 @@ public interface PluginInfoSetLikeTesting<N extends Name & Comparable<N>,
             CharacterConstant.COMMA.toSeparatedString(
                 set,
                 Object::toString
-            )
+            ).replace(",", ", ")
         );
     }
 }

--- a/src/test/java/walkingkooka/plugin/FilteredProviderMapperTest.java
+++ b/src/test/java/walkingkooka/plugin/FilteredProviderMapperTest.java
@@ -255,7 +255,7 @@ public final class FilteredProviderMapperTest implements TreePrintableTesting,
     public void testToString() {
         this.toStringAndCheck(
             MAPPER,
-            "https://example.com/Name Name,https://example.com/RenamedRenameName1/RenamedProviderName1 RenamedRenameName1"
+            "https://example.com/Name Name, https://example.com/RenamedRenameName1/RenamedProviderName1 RenamedRenameName1"
         );
     }
 

--- a/src/test/java/walkingkooka/plugin/MergedProviderMapperTest.java
+++ b/src/test/java/walkingkooka/plugin/MergedProviderMapperTest.java
@@ -273,7 +273,7 @@ public final class MergedProviderMapperTest implements TreePrintableTesting,
     public void testToString() {
         this.toStringAndCheck(
             MAPPER,
-            "https://example.com/NameBoth NameBoth,https://example.com/ProviderOnly ProviderOnlyName,https://example.com/RenamedName-RenamedProviderName RenameName,https://example.com/RenameOnly RenameOnlyName"
+            "https://example.com/NameBoth NameBoth, https://example.com/ProviderOnly ProviderOnlyName, https://example.com/RenamedName-RenamedProviderName RenameName, https://example.com/RenameOnly RenameOnlyName"
         );
     }
 

--- a/src/test/java/walkingkooka/plugin/PluginInfoSetLikeTest.java
+++ b/src/test/java/walkingkooka/plugin/PluginInfoSetLikeTest.java
@@ -517,7 +517,7 @@ public final class PluginInfoSetLikeTest implements PluginInfoSetLikeTesting<Str
                     "test-333"
                 )
             ),
-            "https://example.com/test-111 test-111,https://example.com/test-222 test-222"
+            "https://example.com/test-111 test-111, https://example.com/test-222 test-222"
         );
     }
 
@@ -546,7 +546,7 @@ public final class PluginInfoSetLikeTest implements PluginInfoSetLikeTesting<Str
                     "test-333"
                 )
             ),
-            "https://example.com/test-111 test-111,https://example.com/test-222 test-222"
+            "https://example.com/test-111 test-111, https://example.com/test-222 test-222"
         );
     }
 

--- a/src/test/java/walkingkooka/plugin/PluginInfoSetTest.java
+++ b/src/test/java/walkingkooka/plugin/PluginInfoSetTest.java
@@ -385,7 +385,7 @@ public final class PluginInfoSetTest implements ImmutableSetTesting<PluginInfoSe
                     INFO2
                 )
             ),
-            "https://example.com/a1 a1,https://example.com/b2 b2"
+            "https://example.com/a1 a1, https://example.com/b2 b2"
         );
     }
 


### PR DESCRIPTION
- Closes https://github.com/mP1/walkingkooka-plugin/issues/628
- PluginInfoSet.text() should use SPACE COMMA separator not COMMA